### PR TITLE
Add signKeyPairFromSeed

### DIFF
--- a/src/Crypt/NaCl/Class.purs
+++ b/src/Crypt/NaCl/Class.purs
@@ -74,3 +74,6 @@ instance signSecretKeyUint8ArrayAble :: Uint8ArrayAble SignSecretKey where
 
 instance signedMessageUint8ArrayAble :: Uint8ArrayAble SignedMessage where
   toUint8Array = unsafeCoerce
+
+instance signSeedUint8ArrayAble :: Uint8ArrayAble SignSeed where 
+  toUint8Array = unsafeCoerce

--- a/src/Crypt/NaCl/Sign.js
+++ b/src/Crypt/NaCl/Sign.js
@@ -11,6 +11,10 @@ exports.getSignKeyPair = function(secretKey) {
   return nacl.sign.keyPair.fromSecretKey(secretKey);
 }
 
+exports.getSignKeyPairFromSeed = function(seed) {
+  return nacl.sign.keyPair.fromSeed(seed);
+}
+
 exports.getSignPublicKey = function(signKeyPair) {
   return signKeyPair.publicKey;
 }

--- a/src/Crypt/NaCl/Sign.purs
+++ b/src/Crypt/NaCl/Sign.purs
@@ -21,6 +21,7 @@ import Crypt.NaCl.Types (
   , SignedMessage
   , SignPublicKey
   , SignSecretKey
+  , SignSeed
   )
 
 -- | Generate a random key pair for signing messages
@@ -28,6 +29,9 @@ foreign import generateSignKeyPair :: forall e. Eff (naclRandom :: NACL_RANDOM |
 
 -- | Get the signing keypair for a given `SignSecretKey`
 foreign import getSignKeyPair :: SignSecretKey -> SignKeyPair
+
+-- | Get the signing keypair for a given `SignSeed`
+foreign import getSignKeyPairFromSeed :: SignSeed -> SignKeyPair
 
 -- | Get the `SignPublicKey` for a given `SignKeyPair`
 foreign import getSignPublicKey :: SignKeyPair -> SignPublicKey

--- a/src/Crypt/NaCl/Sign.purs
+++ b/src/Crypt/NaCl/Sign.purs
@@ -10,8 +10,13 @@ module Crypt.NaCl.Sign
   ) where
 
 import Control.Monad.Eff (Eff)
+import Data.ArrayBuffer.ArrayBuffer (byteLength)
+import Data.ArrayBuffer.DataView (buffer)
+import Data.ArrayBuffer.Typed (dataView)
+import Data.ArrayBuffer.Types (Uint8Array)
 import Data.Nullable (Nullable, toMaybe)
 import Data.Maybe (Maybe)
+import Data.Unsafe (unsafeCoerce)
 
 import Crypt.NaCl.Types (
     Message
@@ -56,3 +61,8 @@ foreign import verifyDetached :: Message -> Signature -> Boolean
 -- | or `Nothing` otherwise.
 signOpen :: SignedMessage -> SignPublicKey -> Maybe Message
 signOpen m s = toMaybe (_signOpen m s)
+
+-- | Constructs a `SignSeed` provided the length is 32 bytes.
+mkSignSeed :: Uint8Array -> Maybe SignSeed
+mkSignSeed bs | 32 == (byteLength $ buffer $ dataView bs) = Just (unsafeCoerce bs)
+              | otherwise                                 = Nothing

--- a/src/Crypt/NaCl/Sign.purs
+++ b/src/Crypt/NaCl/Sign.purs
@@ -10,13 +10,8 @@ module Crypt.NaCl.Sign
   ) where
 
 import Control.Monad.Eff (Eff)
-import Data.ArrayBuffer.ArrayBuffer (byteLength)
-import Data.ArrayBuffer.DataView (buffer)
-import Data.ArrayBuffer.Typed (dataView)
-import Data.ArrayBuffer.Types (Uint8Array)
 import Data.Nullable (Nullable, toMaybe)
 import Data.Maybe (Maybe)
-import Data.Unsafe (unsafeCoerce)
 
 import Crypt.NaCl.Types (
     Message
@@ -61,8 +56,3 @@ foreign import verifyDetached :: Message -> Signature -> Boolean
 -- | or `Nothing` otherwise.
 signOpen :: SignedMessage -> SignPublicKey -> Maybe Message
 signOpen m s = toMaybe (_signOpen m s)
-
--- | Constructs a `SignSeed` provided the length is 32 bytes.
-mkSignSeed :: Uint8Array -> Maybe SignSeed
-mkSignSeed bs | 32 == (byteLength $ buffer $ dataView bs) = Just (unsafeCoerce bs)
-              | otherwise                                 = Nothing

--- a/src/Crypt/NaCl/Sign.purs
+++ b/src/Crypt/NaCl/Sign.purs
@@ -1,6 +1,7 @@
 module Crypt.NaCl.Sign
   ( generateSignKeyPair
   , getSignKeyPair
+  , getSignKeyPairFromSeed
   , getSignPublicKey
   , getSignSecretKey
   , signDetached

--- a/src/Crypt/NaCl/Types.purs
+++ b/src/Crypt/NaCl/Types.purs
@@ -48,5 +48,8 @@ foreign import data SignPublicKey :: Type
 -- | A NaCl SignSecretKey
 foreign import data SignSecretKey :: Type
 
+-- | A NaCl SignSeed (a 32 byte seed can be used to generate a 64 byte SignSecretKey)
+foreign import data SignSeed :: Type
+
 -- | A NaCl SignedMessage, which is represented as a Uint8Array in JS
 foreign import data SignedMessage :: Type

--- a/test/Sign.js
+++ b/test/Sign.js
@@ -1,0 +1,19 @@
+exports.testSeedData = {
+  seed: Uint8Array.from(Array(32).fill(0)),
+  publicKey: Uint8Array.from([59,106,39,188,206,182,164,45,98,163,168,208,42,111,13,115,101,50,21,119,29,226,67,166,58,192,72,161,139,89,218,41]),
+  secretKey: Uint8Array.from([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,59,106,39,188,206,182,164,45,98,163,168,208,42,111,13,115,101,50,21,119,29,226,67,166,58,192,72,161,139,89,218,41])
+}
+
+exports.eqUint8Array = function (a1) {
+  return function(a2) {
+    if (a1.byteLength != a2.byteLength) {
+      return false;
+    }
+    for (var i = 0; i < a1.byteLength; i++) {
+      if (a1[i] != a2[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+}


### PR DESCRIPTION
The main point of this PR is to add support for seeds instead of just secret keys. One good reason to do this is that the ed25519 test vectors use seeds instead of raw secret keys.

Because you've implemented foreign data types thus far I'm doing that too. I haven't added a `mkSignSeed` function because it'd introduce dependencies (purescript-arraybuffer particularly).

Also the test logic uses the FFI which I'm not super happy about but the alternative requires adding the dependency mentioned above.