### PR TITLE
Migrate to 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 dist: trusty
 sudo: required
-node_js: 7
+node_js: stable
 install:
   - npm install bower -g
   - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 dist: trusty
 sudo: required
-node_js: 6
+node_js: 7
 install:
   - npm install bower -g
   - npm install

--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,8 @@
     "purescript-arraybuffer-types": "^2.0.0",
     "purescript-nullable": "^4.0.0",
     "purescript-exceptions": "^4.0.0",
-    "purescript-either": "^4.0.0"
+    "purescript-either": "^4.0.0",
+    "purescript-text-encoding": "^0.0.7"
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",

--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,7 @@
     "purescript-nullable": "^4.0.0",
     "purescript-exceptions": "^4.0.0",
     "purescript-either": "^4.0.0",
-    "purescript-text-encoding": "^0.0.7"
+    "purescript-text-encoding": "^0.0.8"
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",

--- a/bower.json
+++ b/bower.json
@@ -22,17 +22,16 @@
     "bower.json"
   ],
   "dependencies": {
-    "purescript-prelude": "^3.0.0",
-    "purescript-eff": "^3.1.0",
-    "purescript-unsafe-coerce": "^3.0.0",
-    "purescript-maybe": "^3.0.0",
+    "purescript-prelude": "^4.0.0",
+    "purescript-effect": "^2.0.0",
+    "purescript-unsafe-coerce": "^4.0.0",
+    "purescript-maybe": "^4.0.0",
     "purescript-arraybuffer-types": "^2.0.0",
-    "purescript-nullable": "^3.0.0",
-    "purescript-encoding": "^0.0.4",
-    "purescript-either": "^3.0.0"
+    "purescript-nullable": "^4.0.0",
+    "purescript-either": "^4.0.0"
   },
   "devDependencies": {
-    "purescript-psci-support": "^3.0.0",
-    "purescript-assert": "^3.0.0"
+    "purescript-psci-support": "^4.0.0",
+    "purescript-assert": "^4.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -28,6 +28,7 @@
     "purescript-maybe": "^4.0.0",
     "purescript-arraybuffer-types": "^2.0.0",
     "purescript-nullable": "^4.0.0",
+    "purescript-exceptions": "^4.0.0",
     "purescript-either": "^4.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -6,13 +6,12 @@
     "test": "pulp test"
   },
   "dependencies": {
-    "text-encoding": "^0.6.4",
-    "tweetnacl": "^1.0.0-rc.1"
+    "tweetnacl": "^1.0.0"
   },
   "devDependencies": {
-    "pulp": "^11.0.0",
-    "purescript": "^0.11.4",
-    "purescript-psa": "^0.5.1",
-    "rimraf": "^2.6.1"
+    "pulp": "^12.3.0",
+    "purescript": "^0.12.0",
+    "purescript-psa": "^0.6.0",
+    "rimraf": "^2.6.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "test": "pulp test"
   },
   "dependencies": {
-    "tweetnacl": "^1.0.0"
+    "tweetnacl": "^1.0.0",
+    "text-encoding": "^0.6.4"
   },
   "devDependencies": {
     "pulp": "^12.3.0",

--- a/src/Crypt/NaCl.purs
+++ b/src/Crypt/NaCl.purs
@@ -9,9 +9,66 @@ module Crypt.NaCl
 ) where
 
 import Crypt.NaCl.Box
+  ( box
+  , boxAfter
+  , boxBefore
+  , boxOpen
+  , boxOpenAfter
+  , generateBoxKeyPair
+  , getBoxKeyPair
+  , getBoxPublicKey
+  , getBoxSecretKey
+  )
+
 import Crypt.NaCl.Class
+  ( class Uint8ArrayAble
+  , class Utf8Decodable
+  , class Utf8Encodable
+  , fromString
+  , toString
+  , toUint8Array
+  )
+
 import Crypt.NaCl.Hash
+  ( hash
+  )
+
 import Crypt.NaCl.Random
+  ( generateNonce
+  , setPRNG
+  )
+
 import Crypt.NaCl.SecretBox
+  ( generateSecretBoxKey
+  , secretBox
+  , secretBoxOpen
+  )
+
 import Crypt.NaCl.Sign
+  ( generateSignKeyPair
+  , getSignKeyPair
+  , getSignPublicKey
+  , getSignSecretKey
+  , sign
+  , signDetached
+  , signOpen
+  , verifyDetached
+  )
+
 import Crypt.NaCl.Types
+  ( Box
+  , BoxKeyPair(..)
+  , BoxPublicKey
+  , BoxSecretKey
+  , BoxSharedKey
+  , HashSha512
+  , Message
+  , Nonce
+  , SecretBox
+  , SecretBoxKey
+  , SignKeyPair(..)
+  , SignPublicKey
+  , SignSecretKey
+  , Signature
+  , SignedMessage
+  )

--- a/src/Crypt/NaCl/Box.purs
+++ b/src/Crypt/NaCl/Box.purs
@@ -11,7 +11,7 @@ module Crypt.NaCl.Box
   ) where
 
 import Prelude (($))
-import Control.Monad.Eff (Eff)
+import Effect (Effect)
 import Data.Nullable (Nullable, toMaybe)
 import Data.Maybe (Maybe)
 

--- a/src/Crypt/NaCl/Box.purs
+++ b/src/Crypt/NaCl/Box.purs
@@ -16,8 +16,7 @@ import Data.Nullable (Nullable, toMaybe)
 import Data.Maybe (Maybe)
 
 import Crypt.NaCl.Types (
-    NACL_RANDOM
-  , Box
+    Box
   , BoxKeyPair
   , BoxPublicKey
   , BoxSecretKey
@@ -28,7 +27,7 @@ import Crypt.NaCl.Types (
 
 
 -- | Generate a `BoxKeyPair` for NaCl Box operations
-foreign import generateBoxKeyPair :: forall e. Eff (naclRandom :: NACL_RANDOM | e) BoxKeyPair
+foreign import generateBoxKeyPair :: forall e. Effect BoxKeyPair
 
 -- | Get a `BoxKeyPair` from the given `BoxSecretKey`
 foreign import getBoxKeyPair :: BoxSecretKey -> BoxKeyPair

--- a/src/Crypt/NaCl/Class.purs
+++ b/src/Crypt/NaCl/Class.purs
@@ -1,6 +1,5 @@
 module Crypt.NaCl.Class where
 
-import Effect
 import Effect.Exception (Error)
 import Data.ArrayBuffer.Types (Uint8Array, Uint8, ArrayView)
 import Data.Either (Either)

--- a/src/Crypt/NaCl/Class.purs
+++ b/src/Crypt/NaCl/Class.purs
@@ -1,6 +1,7 @@
 module Crypt.NaCl.Class where
 
-import Control.Monad.Eff.Exception (Error)
+import Effect
+import Effect.Exception (Error)
 import Data.ArrayBuffer.Types (Uint8Array, Uint8, ArrayView)
 import Data.Either (Either)
 import Data.TextEncoder (encodeUtf8)

--- a/src/Crypt/NaCl/Random.purs
+++ b/src/Crypt/NaCl/Random.purs
@@ -4,10 +4,10 @@ import Data.Unit (Unit)
 import Data.ArrayBuffer.Types (Uint8Array)
 import Effect (Effect)
 
-import Crypt.NaCl.Types (Nonce, NACL_RANDOM)
+import Crypt.NaCl.Types (Nonce)
 
 -- | Assigns a new PRNG for all random data generation
-foreign import setPRNG :: forall e e1. (Uint8Array -> Int -> Eff e1 Unit) -> Eff (naclRandom :: NACL_RANDOM | e) Unit
+foreign import setPRNG :: (Uint8Array -> Int -> Effect Unit) -> Effect Unit
 
 -- | Generate a cryptographically secure, random Nonce for NaCl operations
-foreign import generateNonce:: forall e. Eff (naclRandom :: NACL_RANDOM | e) Nonce
+foreign import generateNonce :: Effect Nonce

--- a/src/Crypt/NaCl/Random.purs
+++ b/src/Crypt/NaCl/Random.purs
@@ -2,7 +2,7 @@ module Crypt.NaCl.Random where
 
 import Data.Unit (Unit)
 import Data.ArrayBuffer.Types (Uint8Array)
-import Control.Monad.Eff (Eff)
+import Effect (Effect)
 
 import Crypt.NaCl.Types (Nonce, NACL_RANDOM)
 

--- a/src/Crypt/NaCl/SecretBox.purs
+++ b/src/Crypt/NaCl/SecretBox.purs
@@ -10,14 +10,13 @@ import Data.Maybe (Maybe)
 
 import Crypt.NaCl.Types (
     Message
-  , NACL_RANDOM
   , Nonce
   , SecretBoxKey
   , SecretBox
   )
 
 -- | Generate a key for use with a `SecretBox`
-foreign import generateSecretBoxKey :: forall e. Eff (naclRandom :: NACL_RANDOM | e) SecretBoxKey
+foreign import generateSecretBoxKey :: Effect SecretBoxKey
 
 -- | Create a SecretBox, which is an encrypted and authenticated message
 foreign import secretBox :: Message -> Nonce -> SecretBoxKey -> SecretBox

--- a/src/Crypt/NaCl/SecretBox.purs
+++ b/src/Crypt/NaCl/SecretBox.purs
@@ -4,7 +4,7 @@ module Crypt.NaCl.SecretBox
   , secretBoxOpen
   ) where
 
-import Control.Monad.Eff (Eff)
+import Effect (Effect)
 import Data.Nullable (Nullable, toMaybe)
 import Data.Maybe (Maybe)
 

--- a/src/Crypt/NaCl/Sign.purs
+++ b/src/Crypt/NaCl/Sign.purs
@@ -9,7 +9,7 @@ module Crypt.NaCl.Sign
   , verifyDetached
   ) where
 
-import Control.Monad.Eff (Eff)
+import Effect (Effect)
 import Data.Nullable (Nullable, toMaybe)
 import Data.Maybe (Maybe)
 

--- a/src/Crypt/NaCl/Sign.purs
+++ b/src/Crypt/NaCl/Sign.purs
@@ -15,7 +15,6 @@ import Data.Maybe (Maybe)
 
 import Crypt.NaCl.Types (
     Message
-  , NACL_RANDOM
   , SignKeyPair
   , Signature
   , SignedMessage
@@ -24,7 +23,7 @@ import Crypt.NaCl.Types (
   )
 
 -- | Generate a random key pair for signing messages
-foreign import generateSignKeyPair :: forall e. Eff (naclRandom :: NACL_RANDOM | e) SignKeyPair
+foreign import generateSignKeyPair :: Effect SignKeyPair
 
 -- | Get the signing keypair for a given `SignSecretKey`
 foreign import getSignKeyPair :: SignSecretKey -> SignKeyPair

--- a/src/Crypt/NaCl/Types.purs
+++ b/src/Crypt/NaCl/Types.purs
@@ -1,7 +1,6 @@
 module Crypt.NaCl.Types where
-import Control.Monad.Eff (kind Effect)
 
-foreign import data NACL_RANDOM :: Effect
+foreign import data NACL_RANDOM :: Type -> Type
 
 -- | A NaCl SHA-512 Hash
 foreign import data HashSha512 :: Type

--- a/src/Crypt/NaCl/Types.purs
+++ b/src/Crypt/NaCl/Types.purs
@@ -1,7 +1,5 @@
 module Crypt.NaCl.Types where
 
-foreign import data NACL_RANDOM :: Type -> Type
-
 -- | A NaCl SHA-512 Hash
 foreign import data HashSha512 :: Type
 

--- a/test/Box.purs
+++ b/test/Box.purs
@@ -1,14 +1,14 @@
 module Test.Box where
 
 import Prelude
-import Control.Monad.Eff (Eff)
+import Effect (Effect)
 import Data.Maybe
 import Test.Assert
 
 import Test.Util
 import Crypt.NaCl
 
-runBoxTests :: forall e. Eff (naclRandom :: NACL_RANDOM, assert :: ASSERT | e) Unit
+runBoxTests :: Effect Unit
 runBoxTests = do
   -- | Setup with 3 keypairs, Alice, Bob, Evil
   aliceKp <- generateBoxKeyPair

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,7 +1,7 @@
 module Test.Main where
 
 import Prelude
-import Control.Monad.Eff (Eff)
+import Effect (Effect)
 import Test.Assert
 
 import Crypt.NaCl
@@ -10,7 +10,7 @@ import Test.Box (runBoxTests)
 import Test.SecretBox (runSecretBoxTests)
 import Test.Sign (runSignTests)
 
-main :: forall e. Eff (naclRandom :: NACL_RANDOM, assert :: ASSERT | e) Unit
+main :: Effect Unit
 main = do
   runSignTests
   runBoxTests

--- a/test/SecretBox.purs
+++ b/test/SecretBox.purs
@@ -1,14 +1,14 @@
 module Test.SecretBox where
 
 import Prelude
-import Control.Monad.Eff (Eff)
+import Effect (Effect)
 import Data.Maybe
 import Test.Assert
 
 import Test.Util
 import Crypt.NaCl
 
-runSecretBoxTests :: forall e. Eff (naclRandom :: NACL_RANDOM, assert :: ASSERT | e) Unit
+runSecretBoxTests :: Effect Unit
 runSecretBoxTests = do
   keyA     <- generateSecretBoxKey
   keyB     <- generateSecretBoxKey

--- a/test/Sign.purs
+++ b/test/Sign.purs
@@ -1,14 +1,14 @@
 module Test.Sign where
 
 import Prelude
-import Control.Monad.Eff (Eff)
+import Effect (Effect)
 import Data.Maybe
 import Test.Assert
 
 import Test.Util
 import Crypt.NaCl
 
-runSignTests :: forall e. Eff (naclRandom :: NACL_RANDOM, assert :: ASSERT | e) Unit
+runSignTests :: Effect Unit
 runSignTests = do
   signKpA  <- generateSignKeyPair
   signKpB  <- generateSignKeyPair


### PR DESCRIPTION
This is currently however blocked the need for a release to TextEncoding.

The PR for which exists here: https://github.com/menelaos/purescript-encoding/pull/2

An additional small commit will need to be added to version bump the bower dep of course.

Alternately, since this library depends very lightly on purescript-encoding, a minimalist re-implementation of the appropriate functions.